### PR TITLE
Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1012,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfprop"
+version = "0.1.0"
+source = "git+https://github.com/JayKickliter/Signal-Server.git?branch=master#81d316bb76d6b9ce10c310a666d338a58bd33cb3"
+dependencies = [
+ "cmake",
+ "cxx",
+ "cxx-build",
+ "thiserror",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,18 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-server"
-version = "0.1.0"
-source = "git+https://github.com/JayKickliter/Signal-Server.git?branch=jsk/add-server#5aed005b3f4305c246b5bfac17db5a976387a697"
-dependencies = [
- "anyhow",
- "cmake",
- "cxx",
- "cxx-build",
- "thiserror",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,11 +1223,11 @@ dependencies = [
  "clap",
  "futures-util",
  "h3o",
+ "rfprop",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "signal-server",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "rfprop"
 version = "0.1.0"
-source = "git+https://github.com/JayKickliter/Signal-Server.git?branch=master#81d316bb76d6b9ce10c310a666d338a58bd33cb3"
+source = "git+https://github.com/JayKickliter/Signal-Server.git?branch=jsk/de-pointer-isze#c921014246c3e26469f93bf085118e66a272541f"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 members = ["mock-client"]
 
 [dependencies]
-signal-server = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "jsk/add-server" }
+rfprop = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "master" }
 axum = { version = "0", features = ["query"] }
 axum-auth = { version = "0", features = ["auth-bearer"] }
 clap = { version = "4", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 members = ["mock-client"]
 
 [dependencies]
-rfprop = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "jsk/de-pointer-isze" }
+rfprop = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "master" }
 axum = { version = "0", features = ["query"] }
 axum-auth = { version = "0", features = ["auth-bearer"] }
 clap = { version = "4", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 members = ["mock-client"]
 
 [dependencies]
-rfprop = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "master" }
+rfprop = { git = "https://github.com/JayKickliter/Signal-Server.git", branch = "jsk/de-pointer-isze" }
 axum = { version = "0", features = ["query"] }
 axum-auth = { version = "0", features = ["auth-bearer"] }
 clap = { version = "4", features = ["derive"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod error;
-pub use error::Error;
-pub type Result<T = ()> = std::result::Result<T, Error>;
+mod server;
 
 pub mod daemon_handle;
-mod server;
+pub use error::Error;
+pub type Result<T = ()> = std::result::Result<T, Error>;
 
 #[derive(Debug, clap::Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,12 +84,16 @@ pub async fn h3plot_handler(
     //AuthBearer(token): AuthBearer
 ) -> HandlerResult {
     let query = query.0;
-    daemon
-        .h3plot(query)
-        .map(|r| {
-            response::Json(json!({
-                "status": "success",
-                "data": r}))
-        })
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+    let join = tokio::task::spawn_blocking(move || {
+        daemon
+            .h3plot(query)
+            .map(|r| {
+                response::Json(json!({
+                    "status": "success",
+                    "data": r}))
+            })
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+    });
+    join.await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,15 +1,19 @@
 use super::*;
-use axum::{extract::Query, http::{header, StatusCode}, response, routing::get, Extension, Router, response::{IntoResponse},};
+use axum::{
+    body::StreamBody,
+    extract::Query,
+    http::{header, StatusCode},
+    response,
+    response::IntoResponse,
+    routing::get,
+    Extension, Router,
+};
 use axum_auth::AuthBearer;
-use axum::body::StreamBody;
 use daemon_handle::DaemonHandle;
-use serde_json::{json, Value};
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
-use std::io;
-
 use futures_util::stream::{self, Stream};
+use serde_json::{json, Value};
+use std::{io, sync::Arc};
+use tokio::sync::Mutex;
 
 pub type HandlerResult = std::result::Result<response::Json<Value>, (StatusCode, String)>;
 
@@ -71,13 +75,9 @@ pub async fn plot_handler(
     //    return Err((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()));
     //}
     let query = query.0;
-    let png = daemon
-        .plot(query)
-        .await.unwrap();
-    
-    let headers = [
-                          (header::CONTENT_TYPE, "image/png"),
-    ];
+    let png = daemon.plot(query).await.unwrap();
+
+    let headers = [(header::CONTENT_TYPE, "image/png")];
 
     (headers, png)
 }


### PR DESCRIPTION
This PR:

1. applies rustfmt
2. fixes lintes
3. cleanup of h3 plotting business logic
4. pulls in latest rfprop crate (formerly known as signal_server)

(3) involves limiting the number of k-rings we plot, and timing out if it takes too long. Additionally, we spawn H3 plotting function in a  blocking thread to not interfere with the scheduler.